### PR TITLE
Fix: Prevent exceeding total refund amount in payment record update

### DIFF
--- a/app/Http/Controllers/PaymentRecordController.php
+++ b/app/Http/Controllers/PaymentRecordController.php
@@ -142,14 +142,16 @@ class PaymentRecordController extends Controller
 
             // Calculate the total refunded amount excluding the current record's amount
             $totalRefundedExcludingCurrent = $refundedAmount - $record->amount;
+            $totalAfterNewAmount = $newAmount + $totalRefundedExcludingCurrent;
+            $isExceedingRefundAmount = bccomp($totalAfterNewAmount, $actualRefundAmount, 2) > 0;
 
-            // Check if the new amount would exceed the total refund amount
-            if ($actualRefundAmount < $newAmount + $totalRefundedExcludingCurrent) {
+            if ($isExceedingRefundAmount) {
                 return response()->json([
                     'success' => false,
                     'message' => 'Payment amount would exceed the total refund amount allowed'
                 ], 422);
             }
+
             $record->update([
                 'Project_id' => $validated['project_id'],
                 'reference_number' => $validated['reference_number'],

--- a/resources/js/staff/PaymentHandler.ts
+++ b/resources/js/staff/PaymentHandler.ts
@@ -103,7 +103,7 @@ export default class PaymentHandler {
             hideProcessToast();
             showToastFeedback('text-bg-success', response.message);
         } catch (error: any) {
-            throw new Error('Failed to update payment records: ' + error);
+            throw new Error(error?.responseJSON?.message || error?.message || 'Failed to update payment records');
         }
     }
 

--- a/resources/js/staff/staff-page.js
+++ b/resources/js/staff/staff-page.js
@@ -1984,7 +1984,7 @@ async function initializeStaffPageJs() {
                             business_id: businessID,
                         },
                     });
-                    showToastFeedback('text-bg-success', data.message);
+                    showToastFeedback('text-bg-success', response?.message || response?.responseJSON?.message   );
                 } catch (error) {
                     showToastFeedback(
                         'text-bg-danger',


### PR DESCRIPTION
This commit fixes an issue where updating a payment record could result in the total refunded amount exceeding the allowed limit. It adds a check to ensure that the new amount, combined with previously refunded amounts, does not surpass the total refund amount.