### PR TITLE
Fix: Corrected element ID for enterprise level input field

### DIFF
--- a/resources/js/application-page.js
+++ b/resources/js/application-page.js
@@ -945,17 +945,17 @@ export function initializeForm() {
             total.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')
         );
         if (total === 0) {
-            $('#Enterprise_Level').text('');
+            $('#EnterpriseLevelInput').text('');
             return;
         }
         if (total < 3e6) {
-            $('#Enterprise_Level').text('Micro Enterprise');
+            $('#EnterpriseLevelInput').text('Micro Enterprise');
         } else if (total < 15e6) {
-            $('#Enterprise_Level').text('Small Enterprise');
+            $('#EnterpriseLevelInput').text('Small Enterprise');
         } else if (total < 100e6) {
-            $('#Enterprise_Level').text('Medium Enterprise');
+            $('#EnterpriseLevelInput').text('Medium Enterprise');
         } else {
-            $('#Enterprise_Level').text('Large Enterprise');
+            $('#EnterpriseLevelInput').text('Large Enterprise');
         }
     }
 


### PR DESCRIPTION
The element ID used to display the enterprise level was incorrect, leading to the value not being displayed. This commit corrects the ID from `Enterprise_Level` to `EnterpriseLevelInput` to ensure the value is displayed correctly.