### PR TITLE
Fix: Pass jQuery object to customFormatNumericInput

### DIFF
--- a/resources/js/application-page.js
+++ b/resources/js/application-page.js
@@ -906,7 +906,7 @@ export function initializeForm() {
             }
         });
 
-    customFormatNumericInput('#personnelContainer', 'input');
+    customFormatNumericInput($('div#personnelContainer'), 'input');
 
     function updateEnterpriseLevel() {
         // Cache DOM selections


### PR DESCRIPTION
The `customFormatNumericInput` function expects a jQuery object, but was being called with a plain DOM element. This commit updates the call to pass the jQuery object to ensure the function works as expected.