### PR TITLE
Create migration for project_forms table with foreign key relationships

### DIFF
--- a/app/Models/ProjectForm.php
+++ b/app/Models/ProjectForm.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProjectForm extends Model
+{
+    protected $table = "project_forms";
+    protected $fillable = [
+        'project_info_id',
+        'application_form_id',
+        'business_info_id',
+        'key',
+        'data',
+        'status'
+    ];
+
+    public function projectInfo(): BelongsTo
+    {
+        return $this->belongsTo(ProjectInfo::class, 'project_info_id', 'Project_id');
+    }
+
+    public function businessInfo(): BelongsTo
+    {
+        return $this->belongsTo(BusinessInfo::class, 'business_info_id', 'id');
+    }
+
+    public function applicationInfo(): BelongsTo
+    {
+        return $this->belongsTo(ApplicationInfo::class, 'application_form_id', 'id');
+    }
+}

--- a/database/migrations/2025_02_28_172835_create_project_forms_table.php
+++ b/database/migrations/2025_02_28_172835_create_project_forms_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('project_forms', function (Blueprint $table) {
+            $table->id();
+            $table->char('project_info_id', 15)->collation('utf8mb4_bin');
+            $table->bigInteger('application_form_id')->unsigned();
+            $table->bigInteger('business_info_id')->unsigned();
+            $table->string('key', 64);
+            $table->json('data');
+            $table->timestamps();
+
+            $table->foreign('project_info_id')->references('Project_id')->on('project_info')->onDelete('cascade')->onUpdate('cascade');
+            $table->foreign('application_info_id')->references('id')->on('application_info')->onDelete('cascade')->onUpdate('cascade');
+            $table->foreign('business_info_id')->references('id')->on('business_info')->onDelete('cascade')->onUpdate('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('project_forms');
+    }
+};


### PR DESCRIPTION
The migration creates a new project_forms or ongoing and completed project table with the following structure:
- Primary ID field
- Foreign keys to project_info, application_form, and business_info tables
- Key field for form identification
- JSON data field to store form content
- Timestamps for record tracking
- Appropriate foreign key constraints with cascade actions