### PR TITLE
Refactor: move toast utility functions to it on js file.

### DIFF
--- a/resources/js/Utilities/ActivityLogHandler.ts
+++ b/resources/js/Utilities/ActivityLogHandler.ts
@@ -1,4 +1,7 @@
-import { customDateFormatter, showToastFeedback } from './utilFunctions';
+import { customDateFormatter } from './utilFunctions';
+import {
+    showToastFeedback,
+} from '../Utilities/feedback-toast';
 import * as bootstrap from 'bootstrap';
 import 'jquery';
 

--- a/resources/js/Utilities/ReportedQuarterlyReportEvent.ts
+++ b/resources/js/Utilities/ReportedQuarterlyReportEvent.ts
@@ -6,11 +6,13 @@ import {
 import {
     parseFormattedNumberToFloat,
     formatNumberToCurrency,
+    serializeFormData,
+} from './utilFunctions';
+import {
     showProcessToast,
     hideProcessToast,
-    serializeFormData,
     showToastFeedback,
-} from './utilFunctions';
+} from '../Utilities/feedback-toast';
 import createConfirmationModal from './confirmation-modal';
 import { TableDataExtractor } from './TableDataExtractor';
 export default class ReportedQuarterlyReportEvent {

--- a/resources/js/Utilities/TabNavigationHandler.ts
+++ b/resources/js/Utilities/TabNavigationHandler.ts
@@ -1,4 +1,7 @@
-import { showToastFeedback } from './utilFunctions';
+
+import {
+    showToastFeedback,
+} from '../Utilities/feedback-toast';
 import 'jquery';
 
 type HTMLContent = string;

--- a/resources/js/Utilities/feedback-toast.ts
+++ b/resources/js/Utilities/feedback-toast.ts
@@ -1,0 +1,89 @@
+import * as bootstrap from 'bootstrap';
+import * as jquery from 'jquery';
+const ProcessToast = $('#ProcessToast');
+const FeedbackToast = $('#ActionFeedbackToast');
+
+/**import * as bootstrap from 'bootstrap';
+ * Shows a Bootstrap toast notification with customizable status and message.
+ * Uses a pre-defined toast element with ID 'ActionFeedbackToast'.
+ *
+ * @param {string} status - Bootstrap text background class for the toast header
+ *                         (e.g., 'text-bg-success', 'text-bg-danger', 'text-bg-warning')
+ * @param {string} message - The message to display in the toast body
+ *
+ * @example
+ * // Show success message
+ * showToastFeedback('text-bg-success', 'Operation completed successfully!');
+ *
+ * @example
+ * // Show error message
+ * showToastFeedback('text-bg-danger', 'An error occurred while processing your request.');
+ *
+ * @example
+ * // Show warning message
+ * showToastFeedback('text-bg-warning', 'Please review your input.');
+ */
+function showToastFeedback(status: string, message: string) {
+    const toastInstance = new bootstrap.Toast(FeedbackToast[0]);
+
+    FeedbackToast.find('.toast-header').removeClass([
+        'text-bg-danger',
+        'text-bg-success',
+        'text-bg-warning',
+        'text-bg-info',
+        'text-bg-primary',
+        'text-bg-light',
+        'text-bg-dark',
+    ]);
+
+    FeedbackToast.find('.toast-body').text('');
+    FeedbackToast.find('.toast-header').addClass(status);
+    FeedbackToast.find('.toast-body').text(message);
+
+    toastInstance.show();
+}
+
+/**
+ * Shows a Bootstrap toast notification for ongoing processes.
+ * Uses a pre-defined toast element with ID 'ProcessToast'.
+ *
+ * @param {string} [message='Processing...'] - Custom message to display in the toast.
+ *                                            If not provided, shows default 'Processing...' message
+ *
+ * @example
+ * // Show default processing message
+ * showProcessToast();
+ *
+ * @example
+ * // Show custom processing message
+ * showProcessToast('Uploading files...');
+ */
+function showProcessToast(message = 'Processing...'): void {
+    const toastInstance = new bootstrap.Toast(ProcessToast[0]);
+
+    // Set the message if provided, otherwise show default spinner
+    if (message) {
+        ProcessToast.find('#ProcessToastBody').html(message);
+    }
+
+    toastInstance.show();
+}
+
+/**
+ * Hides the currently displayed process toast.
+ * Safely handles cases where the toast instance might not exist.
+ *
+ * @example
+ * // Hide process toast after operation completes
+ * showProcessToast('Saving data...');
+ * await saveData();
+ * hideProcessToast();
+ */
+function hideProcessToast(): void {
+    const toastInstance = bootstrap.Toast.getInstance(ProcessToast[0]);
+    if (!toastInstance) {
+        return console.warn('No process toast instance found.');
+    }
+    toastInstance.hide();
+}
+export { showToastFeedback, showProcessToast, hideProcessToast };

--- a/resources/js/Utilities/utilFunctions.ts
+++ b/resources/js/Utilities/utilFunctions.ts
@@ -1,47 +1,5 @@
 import * as bootstrap from 'bootstrap';
 import * as jquery from 'jquery';
-const ProcessToast = $('#ProcessToast');
-const FeedbackToast = $('#ActionFeedbackToast');
-
-/**import * as bootstrap from 'bootstrap';
- * Shows a Bootstrap toast notification with customizable status and message.
- * Uses a pre-defined toast element with ID 'ActionFeedbackToast'.
- *
- * @param {string} status - Bootstrap text background class for the toast header
- *                         (e.g., 'text-bg-success', 'text-bg-danger', 'text-bg-warning')
- * @param {string} message - The message to display in the toast body
- *
- * @example
- * // Show success message
- * showToastFeedback('text-bg-success', 'Operation completed successfully!');
- *
- * @example
- * // Show error message
- * showToastFeedback('text-bg-danger', 'An error occurred while processing your request.');
- *
- * @example
- * // Show warning message
- * showToastFeedback('text-bg-warning', 'Please review your input.');
- */
-function showToastFeedback(status: string, message: string) {
-    const toastInstance = new bootstrap.Toast(FeedbackToast[0]);
-
-    FeedbackToast.find('.toast-header').removeClass([
-        'text-bg-danger',
-        'text-bg-success',
-        'text-bg-warning',
-        'text-bg-info',
-        'text-bg-primary',
-        'text-bg-light',
-        'text-bg-dark',
-    ]);
-
-    FeedbackToast.find('.toast-body').text('');
-    FeedbackToast.find('.toast-header').addClass(status);
-    FeedbackToast.find('.toast-body').text(message);
-
-    toastInstance.show();
-}
 
 /**
  * Formats a number value to a string with a fixed number of decimal places.
@@ -143,50 +101,6 @@ function sanitize(input: string): string {
 }
 
 /**
- * Shows a Bootstrap toast notification for ongoing processes.
- * Uses a pre-defined toast element with ID 'ProcessToast'.
- *
- * @param {string} [message='Processing...'] - Custom message to display in the toast.
- *                                            If not provided, shows default 'Processing...' message
- *
- * @example
- * // Show default processing message
- * showProcessToast();
- *
- * @example
- * // Show custom processing message
- * showProcessToast('Uploading files...');
- */
-function showProcessToast(message = 'Processing...'): void {
-    const toastInstance = new bootstrap.Toast(ProcessToast[0]);
-
-    // Set the message if provided, otherwise show default spinner
-    if (message) {
-        ProcessToast.find('#ProcessToastBody').html(message);
-    }
-
-    toastInstance.show();
-}
-
-/**
- * Hides the currently displayed process toast.
- * Safely handles cases where the toast instance might not exist.
- *
- * @example
- * // Hide process toast after operation completes
- * showProcessToast('Saving data...');
- * await saveData();
- * hideProcessToast();
- */
-function hideProcessToast(): void {
-    const toastInstance = bootstrap.Toast.getInstance(ProcessToast[0]);
-    if (!toastInstance) {
-        return console.warn('No process toast instance found.');
-    }
-    toastInstance.hide();
-}
-
-/**
  * Converts JQuery form data array into a structured object
  * Handles both regular form fields and array fields (with '[]' in the name)
  * @param formData - Array of name-value pairs from a form
@@ -232,14 +146,11 @@ function serializeFormData(
 }
 
 export {
-    showToastFeedback,
     formatNumberToCurrency,
     customDateFormatter,
     closeOffcanvasInstances,
     parseFormattedNumberToFloat,
     closeModal,
     sanitize,
-    showProcessToast,
-    hideProcessToast,
     serializeFormData,
 };

--- a/resources/js/application-page.js
+++ b/resources/js/application-page.js
@@ -1,9 +1,9 @@
+import { formatNumberToCurrency } from './Utilities/utilFunctions';
 import {
     showToastFeedback,
     showProcessToast,
     hideProcessToast,
-    formatNumberToCurrency,
-} from './Utilities/utilFunctions';
+} from './Utilities/feedback-toast';
 import { customFormatNumericInput } from './Utilities/input-utils';
 import { FormDraftHandler } from './Utilities/FormDraftHandler';
 import {

--- a/resources/js/cooperator/coop-page.js
+++ b/resources/js/cooperator/coop-page.js
@@ -2,15 +2,17 @@ import '../echo';
 import { customFormatNumericInput } from '../Utilities/input-utils';
 import createConfirmationModal from '../Utilities/confirmation-modal';
 import {
-    showToastFeedback,
     customDateFormatter,
     formatNumberToCurrency,
     parseFormattedNumberToFloat,
-    showProcessToast,
-    hideProcessToast,
     closeModal,
     serializeFormData,
 } from '../Utilities/utilFunctions';
+import {
+    showProcessToast,
+    hideProcessToast,
+    showToastFeedback,
+} from '../Utilities/feedback-toast';
 import { FormDraftHandler } from '../Utilities/FormDraftHandler';
 import QUARTERLY_REPORTING_FORM_CONFIG from '../Form_Config/QUARTERLY_REPORTING_CONFIG';
 import {

--- a/resources/js/staff/PaymentHandler.ts
+++ b/resources/js/staff/PaymentHandler.ts
@@ -6,7 +6,7 @@ import {
     showProcessToast,
     hideProcessToast,
     showToastFeedback,
-} from '../Utilities/utilFunctions';
+} from '../Utilities/feedback-toast';
 
 export default class PaymentHandler {
     private paymentHistoryDataTableInstance: DataTables.Api;

--- a/resources/js/staff/application-process-form-class.ts
+++ b/resources/js/staff/application-process-form-class.ts
@@ -1,5 +1,6 @@
 
-import { showProcessToast, showToastFeedback, hideProcessToast, serializeFormData } from '../Utilities/utilFunctions';
+import { showProcessToast, showToastFeedback, hideProcessToast } from '../Utilities/feedback-toast';
+import { serializeFormData } from '../Utilities/utilFunctions';
 import BENCHMARKTableConfig from '../Form_Config/form-table-config/tnaFormBenchMarkTableConfig';
 import PROJECT_PROPOSAL_TABLE_CONFIG from '../Form_Config/form-table-config/projectProposalTableConfig';
 import { TableDataExtractor } from '../Utilities/TableDataExtractor';

--- a/resources/js/staff/project-form-class/ProjectClass.ts
+++ b/resources/js/staff/project-form-class/ProjectClass.ts
@@ -1,4 +1,4 @@
-import { showToastFeedback } from '../../Utilities/utilFunctions';
+import { showToastFeedback } from '../../Utilities/feedback-toast';
 
 export default class ProjectClass {
     protected documentBtnSelectors: JQuery<HTMLElement>;

--- a/resources/js/staff/project-form-class/ProjectDataSheet.ts
+++ b/resources/js/staff/project-form-class/ProjectDataSheet.ts
@@ -2,7 +2,7 @@ import {
     showProcessToast,
     showToastFeedback,
     hideProcessToast,
-} from '../../Utilities/utilFunctions';
+} from '../../Utilities/feedback-toast';
 
 import createConfirmationModal from '../../Utilities/confirmation-modal';
 import ProjectClass from './ProjectClass';

--- a/resources/js/staff/project-form-class/ProjectInfoSheet.ts
+++ b/resources/js/staff/project-form-class/ProjectInfoSheet.ts
@@ -1,9 +1,11 @@
 import {
-    showProcessToast,
-    showToastFeedback,
-    hideProcessToast,
     serializeFormData,
 } from '../../Utilities/utilFunctions';
+import {
+    showProcessToast,
+    hideProcessToast,
+    showToastFeedback,
+} from '../../Utilities/feedback-toast';
 
 import createConfirmationModal from '../../Utilities/confirmation-modal';
 import ProjectClass from './ProjectClass';

--- a/resources/js/staff/project-form-class/ProjectStatusReportSheet.ts
+++ b/resources/js/staff/project-form-class/ProjectStatusReportSheet.ts
@@ -1,10 +1,12 @@
 import ProjectClass from './ProjectClass';
 import {
-    hideProcessToast,
-    serializeFormData,
-    showProcessToast,
-    showToastFeedback,
+    serializeFormData
 } from '../../Utilities/utilFunctions';
+import {
+    showProcessToast,
+    hideProcessToast,
+    showToastFeedback,
+} from '../../Utilities/feedback-toast';
 import createConfirmationModal from '../../Utilities/confirmation-modal';
 type Action = 'edit' | 'view';
 export default class ProjectStatusReportSheet extends ProjectClass {

--- a/resources/js/staff/staff-page.js
+++ b/resources/js/staff/staff-page.js
@@ -2,14 +2,16 @@ import '../echo';
 import { customFormatNumericInput } from '../Utilities/input-utils';
 import createConfirmationModal from '../Utilities/confirmation-modal';
 import {
-    showToastFeedback,
     formatNumberToCurrency,
     customDateFormatter,
     closeOffcanvasInstances,
     closeModal,
+} from '../Utilities/utilFunctions';
+import {
+    showToastFeedback,
     showProcessToast,
     hideProcessToast,
-} from '../Utilities/utilFunctions';
+} from '../Utilities/feedback-toast';
 import getProjectPaymentHistory from '../Utilities/project-payment-history';
 import FormEvents from '../components/ProjectFormEvents';
 import EsignatureHandler from '../Utilities/EsignatureHandler';


### PR DESCRIPTION
This pull request focuses on refactoring the toast notification functions by moving them to a new file and updating the relevant imports across multiple files. The most important changes include creating a new `feedback-toast.ts` file, moving the toast functions there, and updating the import statements in various files to reflect this change.

Refactoring and code organization:

* Created a new file `resources/js/Utilities/feedback-toast.ts` to house the `showToastFeedback`, `showProcessToast`, and `hideProcessToast` functions. This change includes adding detailed comments and examples for each function.

Import statement updates:

* Updated `resources/js/Utilities/ActivityLogHandler.ts` to import `showToastFeedback` from the new `feedback-toast.ts` file.
* Updated `resources/js/Utilities/ReportedQuarterlyReportEvent.ts` to import `showProcessToast`, `hideProcessToast`, and `showToastFeedback` from the new `feedback-toast.ts` file.
* Updated `resources/js/Utilities/TabNavigationHandler.ts` to import `showToastFeedback` from the new `feedback-toast.ts` file.
* Updated `resources/js/application-page.js` to import `showToastFeedback`, `showProcessToast`, and `hideProcessToast` from the new `feedback-toast.ts` file.

Removal of old toast functions:

* Removed the `showToastFeedback`, `showProcessToast`, and `hideProcessToast` functions from `resources/js/Utilities/utilFunctions.ts` as they have been moved to the new `feedback-toast.ts` file. [[1]](diffhunk://#diff-bdfd882a26ae5a624769b347ef0b002e254cbd1e118c1e7e2a3605c3c2996f1fL3-L44) [[2]](diffhunk://#diff-bdfd882a26ae5a624769b347ef0b002e254cbd1e118c1e7e2a3605c3c2996f1fL145-L188) [[3]](diffhunk://#diff-bdfd882a26ae5a624769b347ef0b002e254cbd1e118c1e7e2a3605c3c2996f1fL235-L243)