### PR TITLE
refactor(business_info): update the enum column of the enterprise_type

### DIFF
--- a/database/migrations/2024_07_22_152328_create_business_info_table.php
+++ b/database/migrations/2024_07_22_152328_create_business_info_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
             $table->id();
             $table->bigInteger('user_info_id')->unsigned();
             $table->string('firm_name', 40);
-            $table->enum('enterprise_type', ['Sole Proprietorship', 'Partnership', 'Corporation']);
-            $table->enum('enterprise_level', ['Micro Enterprise', 'Small Enterprise', 'Medium Enterprise' ]);
+            $table->enum('enterprise_type', ['Sole Proprietorship', 'Partnership', 'Corporation (Profit)', 'Corporation (Non-profit)']);
+            $table->enum('enterprise_level', ['Micro Enterprise', 'Small Enterprise', 'Medium Enterprise', 'Large Enterprise']);
             $table->string('zip_code', 10);
             $table->string('landMark', 64);
             $table->string('barangay', 64);

--- a/resources/views/components/applicant-form.blade.php
+++ b/resources/views/components/applicant-form.blade.php
@@ -616,16 +616,14 @@
                                     Proprietorship</option>
                                 <option value="Partnership">Partnership
                                 </option>
-                                <option value="Corporation">Corporation</option>
-                                {{-- TODO: Edit the Enum values of the database for Non-Profit and Profit --}}
-                                {{-- <option
+                                <option
                                     value="Corporation (Non-Profit)"
                                 >Corporation (Non-Profit)
                                 </option>
                                 <option
                                     value="Corporation (Profit)"
                                 >Corporation (Profit)
-                                </option> --}}
+                                </option>
                             </select>
                             <div class="invalid-feedback">
                                 Please select a type of enterprise.

--- a/resources/views/registerpage/application.blade.php
+++ b/resources/views/registerpage/application.blade.php
@@ -81,30 +81,6 @@
             /* Adjust the width as needed */
         }
 
-        fieldset legend {
-            position: absolute;
-            /* Set position to absolute */
-            top: -20px;
-            /* Adjust this value to move legend up */
-            /* Match the background color to your form or page background */
-            color: #495057;
-            border-radius: 0.25rem;
-            padding: 0.5rem;
-            font-size: 1rem;
-            font-weight: bold;
-            left: 10px;
-            /* Adjust horizontally if needed */
-        }
-
-        /* Additional styling to ensure the fieldset and its contents look integrated */
-        fieldset {
-            position: relative;
-            /* Added position relative */
-            padding: 2rem;
-            border: 2px solid #dee2e6;
-            border-radius: 0.25rem;
-        }
-
         .form-label {
             font-weight: bold;
         }


### PR DESCRIPTION
This pull request includes changes to the `database/migrations`, `resources/views/components`, and `resources/views/registerpage` files to update the enterprise type and level options, and to clean up some form styling.

Updates to enterprise type and level options:

* [`database/migrations/2024_07_22_152328_create_business_info_table.php`](diffhunk://#diff-44983f876ea5f7bb6aed8434fa7b0124deedd3edcf1d6103b4ed96b21da7efe2L18-R19): Updated the `enterprise_type` and `enterprise_level` enum values to include 'Corporation (Profit)', 'Corporation (Non-profit)', and 'Large Enterprise'.
* [`resources/views/components/applicant-form.blade.php`](diffhunk://#diff-4ef757b6eb98f54bab5bbcd6808dcdc3b5fe47bc043e610ef13cece7ed204b4dL619-R626): Updated the form options to reflect the new `enterprise_type` enum values, removing the TODO comments.

Styling cleanup:

* [`resources/views/registerpage/application.blade.php`](diffhunk://#diff-f94d5a790597bba0b1b57d63924fab060fed240f4151d24863f7b4770c567029L84-L107): Removed the custom styling for `fieldset` and `legend` elements to simplify the CSS and improve maintainability.