### PR TITLE
Fix: incorrect reference to projectFileClass in staff-page.js

### DIFF
--- a/resources/js/staff/staff-page.js
+++ b/resources/js/staff/staff-page.js
@@ -1361,7 +1361,9 @@ async function initializeStaffPageJs() {
                                 uniqueVal
                             ),
                         afterDelete: async (project_id) =>
-                            await projectFileClass.getProjectLinks(project_id),
+                            await classInstance.projectFileClass.getProjectLinks(
+                                project_id
+                            ),
                     },
                     quarterlyRecord: {
                         getMessage: () => {


### PR DESCRIPTION
The commit updates the afterDelete callback in staff-page.js to correctly reference projectFileClass through the classInstance object. This fixes a potential reference error that would occur when attempting to call getProjectLinks after deleting a project.