### PR TITLE
feat: add optional headers parameter to TabNavigationHandler.loadTab …

### DIFF
--- a/resources/js/Utilities/TabNavigationHandler.ts
+++ b/resources/js/Utilities/TabNavigationHandler.ts
@@ -68,10 +68,15 @@ export default class NavigationHandler {
      * Loads a page content via AJAX or from session storage cache
      * @param {string} url - The URL of the page to load
      * @param {string} activeLink - The ID of the navigation link to activate
+     * @param {Record<string, string>} [optionalHeaders] - Optional headers to be sent with the request
      * @returns {Promise<void>}
      * @throws {Error} When page loading fails
      */
-    public async loadTab(url: string, activeLink: string): Promise<void> {
+    public async loadTab(
+        url: string,
+        activeLink: string,
+        optionalHeaders?: Record<string, string>
+    ): Promise<void> {
         try {
             $(document).trigger('page:changing', {
                 from: this.currentPage,
@@ -91,6 +96,7 @@ export default class NavigationHandler {
                     method: 'GET',
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
+                        ...optionalHeaders,
                     },
                 });
                 const html = await response.text();


### PR DESCRIPTION
…method
This pull request includes a modification to the `NavigationHandler` class in `resources/js/Utilities/TabNavigationHandler.ts` to support optional headers when loading a page tab. The most important changes are:

* Added an optional `optionalHeaders` parameter to the `loadTab` method to allow passing additional headers with the request.
* Updated the AJAX request within the `loadTab` method to include the `optionalHeaders` in the request headers.