### PR TITLE
Adds nullable sectors field to project request

### DIFF
--- a/app/Http/Requests/StoreExistingProjectRequest.php
+++ b/app/Http/Requests/StoreExistingProjectRequest.php
@@ -203,6 +203,8 @@ class StoreExistingProjectRequest extends FormRequest
             'factory_faxNo' => 'nullable',
             'factory_emailAddress' => 'nullable|email',
 
+            'sectors' => 'nullable',
+
             'buildings' => 'required',
             'equipments' => 'required',
             'working_capital' => 'required',


### PR DESCRIPTION
This pull request includes a small change to the `app/Http/Requests/StoreExistingProjectRequest.php` file. The change adds a new nullable field `sectors` to the validation rules.

* [`app/Http/Requests/StoreExistingProjectRequest.php`](diffhunk://#diff-25fb16ede67b40afecc5e89bbbad6f8afcf5f4599e5fd9cab59e00a0cdc37542R206-R207): Added the `sectors` field as nullable in the `rules` method.Includes 'sectors' as a nullable field in the validation rules to support scenarios where sector information is optional.